### PR TITLE
docs: remove duplicate in storage-account.md

### DIFF
--- a/docs/scraping/providers/storage-account.md
+++ b/docs/scraping/providers/storage-account.md
@@ -33,8 +33,6 @@ azureMetricConfiguration:
 resources: # Optional, required when no resource discovery is configured
 - accountName: promitor-1
 - accountName: promitor-2
-resourceDiscoveryGroups:
-- name: storage-accounts
 resourceDiscoveryGroups: # Optional, requires Promitor Resource Discovery agent (https://promitor.io/concepts/how-it-works#using-resource-discovery)
 - name: storage-account-landscape
 ```


### PR DESCRIPTION
Removed duplicate `resourceDiscoveryGroups` from example in  storage-account.md

Signed-off-by: Maciek Gołaszewski <m.k.golaszewski@gmail.com>


Fixes #
