### PR TITLE
docs: Fix Link to Supported Azure Services in labels.md

### DIFF
--- a/docs/scraping/labels.md
+++ b/docs/scraping/labels.md
@@ -41,7 +41,7 @@ Currently we support this for:
 - Azure Storage Queue
 - Azure Web App
 
-For more information, we recommend reading the [scraper-specific documentation](./../configuration/v1.x/metrics/#supported-azure-services).
+For more information, we recommend reading the [scraper-specific documentation](./../overview#supported-azure-services).
 
 ## Custom Labels
 


### PR DESCRIPTION
`scraper-specific documentation` on https://docs.promitor.io/v2.8/scraping/labels/ leads to https://docs.promitor.io/v2.8/scraping/configuration/v1.x/metrics/#supported-azure-services currently