### PR TITLE
docs: identityId is optional when using UserAssignedManagedIdentity

### DIFF
--- a/docs/resource-discovery/runtime-configuration.md
+++ b/docs/resource-discovery/runtime-configuration.md
@@ -43,7 +43,7 @@ The Promitor runtime allows you to use various ways to authenticate to Azure:
 - `authentication.mode` - Defines authentication mode to use. Options are `ServicePrincipal`,
  `SystemAssignedManagedIdentity`, `UserAssignedManagedIdentity`. _(defaults to service principle)_
 - `authentication.identityId` - Id of the Azure AD entity to authenticate with when integrating with Microsoft Azure.
- Required when using `ServicePrincipal` or `UserAssignedManagedIdentity`.
+ Required when using `ServicePrincipal`.
 
 Example:
 

--- a/docs/scraping/runtime-configuration.md
+++ b/docs/scraping/runtime-configuration.md
@@ -74,7 +74,7 @@ The Promitor runtime allows you to use various ways to authenticate to Azure:
 - `authentication.mode` - Defines authentication mode to use. Options are `ServicePrincipal`,
  `SystemAssignedManagedIdentity`, `UserAssignedManagedIdentity`. _(defaults to service principle)_
 - `authentication.identityId` - Id of the Azure AD entity to authenticate with when integrating with Microsoft Azure.
- Required when using `ServicePrincipal` or `UserAssignedManagedIdentity`.
+ Required when using `ServicePrincipal`.
 
 Example:
 


### PR DESCRIPTION
Related to [feat(auth): make client id optional when using user assigned managed identity](https://github.com/tomkerkhove/promitor/pull/2247).
Related to https://github.com/tomkerkhove/promitor/issues/2237