### PR TITLE
feat: support for mounting service principal authentication secret as a file

### DIFF
--- a/docs/security/azure-authentication.md
+++ b/docs/security/azure-authentication.md
@@ -33,7 +33,7 @@ Every agent needs to be configured with the following environment variables:
 
 - **PROMITOR_AUTH_APPKEY** - Secret of the Azure AD entity to authenticate with
 
-The app key can be read from a file by specifying the file's location:
+The app key can also be read from a file by specifying the file's location:
 
 ```yaml
 azureAuthentication:

--- a/docs/security/azure-authentication.md
+++ b/docs/security/azure-authentication.md
@@ -33,6 +33,16 @@ Every agent needs to be configured with the following environment variables:
 
 - **PROMITOR_AUTH_APPKEY** - Secret of the Azure AD entity to authenticate with
 
+The app key can be read from a file by specifying the file's location:
+
+```yaml
+azureAuthentication:
+  identity: 
+    id: # [app id]
+    secretFilePath: # [the name of the folder containing the secret file]
+    secretFileName: # [the name of the file containing the app key]
+```
+
 ### Managed Identity Authentication
 
 ![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.2-green.svg)


### PR DESCRIPTION
Added a section describing how to read app key from a file

Relates to https://github.com/tomkerkhove/promitor/pull/2184
Relates to https://github.com/tomkerkhove/promitor/issues/2186