### PR TITLE
fix: Link to Azure Function metrics

### DIFF
--- a/docs/scraping/providers/function-app.md
+++ b/docs/scraping/providers/function-app.md
@@ -18,7 +18,10 @@ When using declared resources, the following fields need to be provided:
 - `functionAppName` - The name of the Azure Function App
 - `slotName` - The name of the deployment slot *(optional)*
 
-All supported metrics are documented in the official [Azure Monitor documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics) under [Microsoft.Web/sites](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics) and [Microsoft.Web/sites/slots](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-slots-metrics).
+All supported metrics are documented in the official Azure Monitor documentation:
+
+- [Microsoft.Web/sites](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics)
+- [Microsoft.Web/sites/slots](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-slots-metrics)
 
 The following scraper-specific metric label will be added:
 

--- a/docs/scraping/providers/function-app.md
+++ b/docs/scraping/providers/function-app.md
@@ -18,7 +18,7 @@ When using declared resources, the following fields need to be provided:
 - `functionAppName` - The name of the Azure Function App
 - `slotName` - The name of the deployment slot *(optional)*
 
-All supported metrics are documented in the official [Azure Monitor documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebsites-functions).
+All supported metrics are documented in the official [Azure Monitor documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics) under [Microsoft.Web/sites](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics) and [Microsoft.Web/sites/slots](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-slots-metrics).
 
 The following scraper-specific metric label will be added:
 


### PR DESCRIPTION
This is to update the docs regarding function app metrics.

The current link (https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebsites-functions) redirects you here: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/metrics-index