### PR TITLE
feat(docs): add DNS Zone support

### DIFF
--- a/docs/resource-discovery/declaring-resource-discovery-groups.md
+++ b/docs/resource-discovery/declaring-resource-discovery-groups.md
@@ -1,18 +1,18 @@
 # Declaring resource discovery groups
 
 Promitor Resource Discovery allows you to declare the Azure landscape to explore and define resource discovery groups
- in YAML.
+in YAML.
 
 Resource discovery groups represent a group of Azure resources of a given type that can be scraped by Promitor Scraper
- and supports an extensive list of supported services.
+and supports an extensive list of supported services.
 
 As part of the resource discovery group declaration, you can choose to filter resources by adding inclusion criteria
- that resources must comply with based on:
+that resources must comply with based on:
 
 - **Subscription** - Defines a subset of subscriptions defined in the Azure landscape
 - **Resource Group** - Defines a list of resource groups which contains the resources.
 - **Tags** - Defines a list of [Azure tags](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources)
- with which the resources have to be annotated.
+  with which the resources have to be annotated.
 - **Regions** - Defines a list of Azure regions in which the regions the resources are located.
 
 Here is an example of a full declaration using a custom cloud:
@@ -22,9 +22,9 @@ version: v1
 azureLandscape:
   tenantId: e0372f7f-a362-47fb-9631-74a5c4ba8bbf
   subscriptions:
-  - SUBSCRIPTON-ID-ABC
-  - SUBSCRIPTON-ID-DEF
-  - SUBSCRIPTON-ID-GHI
+    - SUBSCRIPTON-ID-ABC
+    - SUBSCRIPTON-ID-DEF
+    - SUBSCRIPTON-ID-GHI
   cloud: Custom
   endpoints:
     authenticationEndpoint: https://custom-authentication-endpoint
@@ -34,24 +34,26 @@ azureLandscape:
     storageEndpointSuffix: custom-storage-endpoint-suffix
     keyVaultSuffix: custom-key-vault-suffix
 resourceDiscoveryGroups:
-- name: container-registry-landscape
-  type: ContainerRegistry
-- name: filtered-logic-apps-landscape
-  type: LogicApp
-  criteria:
-    include:
-      subscriptions:
-      - SUBSCRIPTON-ID-ABC
-      - SUBSCRIPTON-ID-GHI
-      resourceGroups:
-      - promitor-resource-group-1
-      - promitor-resource-group-2
-      tags:
-        app: promitor-1|promitor-2
-        region: europe
-      regions:
-      - northeurope
-      - westeurope
+  - name: container-registry-landscape
+    type: ContainerRegistry
+  - name: dns-zone-landscape
+    type: DnsZone
+  - name: filtered-logic-apps-landscape
+    type: LogicApp
+    criteria:
+      include:
+        subscriptions:
+          - SUBSCRIPTON-ID-ABC
+          - SUBSCRIPTON-ID-GHI
+        resourceGroups:
+          - promitor-resource-group-1
+          - promitor-resource-group-2
+        tags:
+          app: promitor-1|promitor-2
+          region: europe
+        regions:
+          - northeurope
+          - westeurope
 ```
 
 ## Specification
@@ -59,37 +61,37 @@ resourceDiscoveryGroups:
 As Promitor evolves we need to change the structure of our resource discovery declaration.
 
 `version: {version}` - Version of declaration that is used. Allowed
-values are `v1`. *(Required)*
+values are `v1`. _(Required)_
 
 ### Azure Landscape
 
-- `azureLandscape.tenantId` - The id of the Azure tenant that will be queried. *(Required)*
-- `azureLandscape.subscriptions` - List of Azure subscriptions in the Azure tenant to discover resources in. *(Required)*
+- `azureLandscape.tenantId` - The id of the Azure tenant that will be queried. _(Required)_
+- `azureLandscape.subscriptions` - List of Azure subscriptions in the Azure tenant to discover resources in. _(Required)_
 - `azureLandscape.cloud` - The name of the Azure cloud to use. Options are `Global`
- (default), `China`, `UsGov`, `Germany`, & `Custom`.
+  (default), `China`, `UsGov`, `Germany`, & `Custom`.
 - `azureLandscape.endpoints` - Required when `azureLandscape.cloud` is set to `Custom`. Defines the custom endpoints to use:
-    - `authenticationEndpoint` - The custom authentication endpoint.
-    - `managementEndpoint` - The custom service management endpoint.
-    - `resourceManagerEndpoint` - The custom Azure ARM resource management endpoint.
-    - `graphEndpoint` - The custom Active Directory graph endpoint.
-    - `storageEndpointSuffix` - The custom storage service url suffix.
-    - `keyVaultSuffix` - The custom Key Vault service url suffix.
+  - `authenticationEndpoint` - The custom authentication endpoint.
+  - `managementEndpoint` - The custom service management endpoint.
+  - `resourceManagerEndpoint` - The custom Azure ARM resource management endpoint.
+  - `graphEndpoint` - The custom Active Directory graph endpoint.
+  - `storageEndpointSuffix` - The custom storage service url suffix.
+  - `keyVaultSuffix` - The custom Key Vault service url suffix.
 
 ### Resource Discovery Groups
 
 Every resource discovery group that is being declared needs to define the following fields:
 
-- `name` - Name of the resource discovery group which will be used in metrics declaration of Promitor Scraper. *(Required)*
-- `type` - Type of Azure resources that must be discovered, see "Supported Azure Services" for a full list of supported types. *(Required)*
+- `name` - Name of the resource discovery group which will be used in metrics declaration of Promitor Scraper. _(Required)_
+- `type` - Type of Azure resources that must be discovered, see "Supported Azure Services" for a full list of supported types. _(Required)_
 - `criteria` - Criteria to fine-tune discovered resource.
 
 #### Criteria
 
 As of now, we only allow to define criteria that resources have to meet before they are included in the resource
- discovery group:
+discovery group:
 
 - `subscriptions` - A list of subscription(s) in which the resource is allowed to be located.
 - `resourceGroups` - A list of resource group(s) in which the resource is allowed to be located.
 - `tags` - A list of [Azure tags](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources)
- and the expected values (exact or regular expression) with which the resources have to be annotated. (Uses `or`)
+  and the expected values (exact or regular expression) with which the resources have to be annotated. (Uses `or`)
 - `regions` - A list of Azure region(s) in which the resource is allowed to be located.

--- a/docs/scraping/overview.md
+++ b/docs/scraping/overview.md
@@ -6,7 +6,7 @@ file which is referred to as the metric declaration.
 This declaration defines the overall Azure metadata and all the metrics you want to expose.
 
 Every metric describes the Azure Monitor metric that it represents and what Azure resources that should be scraped.
- It allows you to statically declaring the resources to scrape and/or use [automatic resource discovery](https://promitor.io/concepts/#using-resource-discovery).
+It allows you to statically declaring the resources to scrape and/or use [automatic resource discovery](https://promitor.io/concepts/#using-resource-discovery).
 
 ## Supported Azure Services
 
@@ -28,6 +28,7 @@ We also provide a simplified way to scrape the following Azure resources:
 - [Azure Data Factory](providers/data-factory.md)
 - [Azure Data Share](providers/data-share.md)
 - [Azure Database for PostgreSQL](providers/postgresql.md)
+- [Azure DNS Zone](providers/dns-zone.md)
 - [Azure Database for MariaDB](providers/maria-db.md)
 - [Azure Database for MySQL](providers/mysql.md)
 - [Azure Event Hubs](providers/event-hubs.md)
@@ -67,7 +68,7 @@ Want to help out? Create an issue and [contribute a new scraper](https://github.
 As Promitor evolves we need to change the structure of our metrics declaration.
 
 `version: {version}` - Version of declaration that is used. Allowed
-values are `v1`. *(Required)*
+values are `v1`. _(Required)_
 
 ### Azure
 
@@ -75,17 +76,17 @@ values are `v1`. *(Required)*
 - `azureMetadata.subscriptionId` - The id of the default subscription to query.
 - `azureMetadata.resourceGroupName` - The name of the default resource group to query.
 - `azureMetadata.cloud` - The name of the Azure cloud to use. Options are `Global`
- (default), `China`, `UsGov`, `Germany`, & `Custom`.
+  (default), `China`, `UsGov`, `Germany`, & `Custom`.
 - `azureMetadata.endpoints` - Required when `azureMetadata.cloud` is set to `Custom`. Defines the custom endpoints to use:
-    - `authenticationEndpoint` - The custom authentication endpoint.
-    - `managementEndpoint` - The custom service management endpoint.
-    - `resourceManagerEndpoint` - The custom Azure ARM resource management endpoint.
-    - `graphEndpoint` - The custom Active Directory graph endpoint.
-    - `storageEndpointSuffix` - The custom storage service url suffix.
-    - `keyVaultSuffix` - The custom Key Vault service url suffix.
-    - `metricsQueryAudience` - The custom audiences available for metrics query.
-    - `metricsClientAudience` - The custom audiences available for metrics client.
-    - `logAnalyticsEndpoint` - The custom log analytics endpoint. *(Required only if Azure Log Analytics resource is configured for scraping)*
+  - `authenticationEndpoint` - The custom authentication endpoint.
+  - `managementEndpoint` - The custom service management endpoint.
+  - `resourceManagerEndpoint` - The custom Azure ARM resource management endpoint.
+  - `graphEndpoint` - The custom Active Directory graph endpoint.
+  - `storageEndpointSuffix` - The custom storage service url suffix.
+  - `keyVaultSuffix` - The custom Key Vault service url suffix.
+  - `metricsQueryAudience` - The custom audiences available for metrics query.
+  - `metricsClientAudience` - The custom audiences available for metrics client.
+  - `logAnalyticsEndpoint` - The custom log analytics endpoint. _(Required only if Azure Log Analytics resource is configured for scraping)_
 
 ### Metric Defaults
 
@@ -98,7 +99,7 @@ values are `v1`. *(Required)*
 - `metricDefaults.scraping.schedule` - A cron expression that controls
   the frequency of which all the configured metrics will be scraped from Azure Monitor.
   You can use [crontab-generator.org](https://crontab-generator.org/) to generate
-  a cron that fits your needs. *(Required)*
+  a cron that fits your needs. _(Required)_
 
 ### Metrics
 
@@ -119,7 +120,7 @@ Every metric that is being declared needs to define the following fields:
 - `azureMetricConfiguration.limit` - The maximum amount of resources to scrape when using dimensions
   or filters.
 - `resourceDiscoveryGroups` An array of one or more resource discovery groups that will be used to automatically
- discover all resources through Promitor Resource Discovery. For every found resource, it will get the metrics and
+  discover all resources through Promitor Resource Discovery. For every found resource, it will get the metrics and
   report them. Learn more on resource discovery, in [our documentation](https://promitor.io/concepts#using-resource-discovery)
 
 All resources provide the capability to override the default Azure metadata:
@@ -130,10 +131,10 @@ All resources provide the capability to override the default Azure metadata:
 Additionally, the following fields are optional:
 
 - `azureMetricConfiguration.dimensions` - A list of dimensions that should
-   be used to scrape a multi-dimensional metric in Azure Monitor.
-  - ☝ *Promitor simply acts as a proxy and will not validate if the given dimensions are supported or
-     not, we recommend verifying that they are in the
-     [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)*
+  be used to scrape a multi-dimensional metric in Azure Monitor.
+  - ☝ _Promitor simply acts as a proxy and will not validate if the given dimensions are supported or
+    not, we recommend verifying that they are in the
+    [official documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)_
 - `labels` - Defines a set of custom labels to include for a given metric.
 - `scraping.schedule` - A scraping schedule for the individual metric; overrides
   the the one specified in `metricDefaults`
@@ -199,7 +200,7 @@ metrics:
         resourceGroupName: promitor-dev
         subscriptionId: ABC
     resourceDiscoveryGroups: # Optional, requires Promitor Resource Discovery agent (https://promitor.io/concepts/how-it-works#using-resource-discovery)
-    - name: service-bus-landscape
+      - name: service-bus-landscape
 ```
 
 [&larr; back](../index.md)

--- a/docs/scraping/providers/dns-zone.md
+++ b/docs/scraping/providers/dns-zone.md
@@ -8,7 +8,7 @@ tags:
 
 # Azure DNS Zone
 
-![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.12-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
+![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.5-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
 
 You can declare to scrape an Azure DNS Zone via the `DnsZone` resource type.
 

--- a/docs/scraping/providers/dns-zone.md
+++ b/docs/scraping/providers/dns-zone.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - Scraper
+  - Resource Discovery
+  - Networking
+  - DNS
+---
+
+# Azure DNS Zone
+
+![Availability Badge](https://img.shields.io/badge/Available%20Starting-v2.12-green.svg)![Resource Discovery Support Badge](https://img.shields.io/badge/Support%20for%20Resource%20Discovery-Yes-green.svg)
+
+You can declare to scrape an Azure DNS Zone via the `DnsZone` resource type.
+
+When using declared resources, the following fields need to be provided:
+
+- `zoneName` - The name of the DNS zone
+
+All supported metrics are documented in the official [Azure Monitor documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkdnszones).
+
+## Example
+
+Here is an example configuration:
+
+```yaml
+name: azure_dns_zone_capacity_utilization
+description: "Percentage of record set capacity utilized by a DNS zone"
+resourceType: DnsZone
+scraping:
+  schedule: "0 */2 * ? * *"
+azureMetricConfiguration:
+  metricName: RecordSetCapacityUtilization
+  aggregation:
+    type: Maximum
+    interval: 00:01:00
+resources: # Optional, required when no resource discovery is configured
+  - zoneName: promitor.io
+  - zoneName: api.promitor.io
+resourceDiscoveryGroups: # Optional, requires Promitor Resource Discovery agent (https://docs.promitor.io/latest/how-it-works#using-resource-discovery)
+  - name: dns-zone-landscape
+```

--- a/docs/scraping/providers/dns-zone.md
+++ b/docs/scraping/providers/dns-zone.md
@@ -16,7 +16,7 @@ When using declared resources, the following fields need to be provided:
 
 - `zoneName` - The name of the DNS zone
 
-All supported metrics are documented in the official [Azure Monitor documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkdnszones).
+All supported metrics are documented in the official [Azure Monitor documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-network-dnszones-metrics).
 
 ## Example
 

--- a/docs/thank-you.md
+++ b/docs/thank-you.md
@@ -54,14 +54,14 @@ Here is an overview of the services that are so kind to support us:
 We are using the following GitHub Apps:
 
 - [Semantic Pull Requests](https://github.com/apps/semantic-pull-requests) - Ensure PRs are using a
-consistent approach.
+  consistent approach.
 - [Task list completed](https://github.com/marketplace/task-list-completed) -
   Ensures all task lists in our PRs are completed.
 - [Triage New Issues](https://github.com/apps/triage-new-issues) - Automatically
   tag new issues & PRs with `triage` label.
 - [Request Info](https://github.com/apps/request-info) - Requests more info from
   newly opened Pull Requests and Issues.
-- [YAMBURGER](https://github.com/apps/yamburger) - Finds YAML syntax errors.
+- **YAMBURGER** - Finds YAML syntax errors. _(Archived as of August 2025)_
 - [Reminders](https://github.com/apps/reminders) - Set reminders on Issues and
   Pull Requests.
 - [Check TODO](https://github.com/marketplace/check-todo) - Check TODO allows you
@@ -85,9 +85,9 @@ Here is an overview of the NuGet packages that we rely on:
 - [Prometheus.Client](https://github.com/PrometheusClientNet/Prometheus.Client)
   - .NET client for prometheus.io
 - [spectre.console](https://github.com/spectresystems/spectre.console) - A library that makes it easier to create
- beautiful console applications.
+  beautiful console applications.
 - [Humanizer](https://github.com/Humanizr/Humanizer) - Humanizer meets all your .NET needs for manipulating and
- displaying strings, enums, dates, times, timespans, numbers and quantities
+  displaying strings, enums, dates, times, timespans, numbers and quantities
 - [YamlDotNet](https://github.com/aaubry/YamlDotNet) - .NET library for YAML
 - [Guard.NET](https://github.com/george-pancescu/Guard) - Library that facilitates
   runtime checks of code and allows to define preconditions and invariants within

--- a/docs/thank-you.md
+++ b/docs/thank-you.md
@@ -57,8 +57,7 @@ We are using the following GitHub Apps:
   consistent approach.
 - [Task list completed](https://github.com/marketplace/task-list-completed) -
   Ensures all task lists in our PRs are completed.
-- [Triage New Issues](https://github.com/apps/triage-new-issues) - Automatically
-  tag new issues & PRs with `triage` label.
+- **Triage New Issues** - Automatically tag new issues & PRs with `triage` label. _(No longer available)_
 - [Request Info](https://github.com/apps/request-info) - Requests more info from
   newly opened Pull Requests and Issues.
 - **YAMBURGER** - Finds YAML syntax errors. _(Archived as of August 2025)_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,6 @@ theme:
   # Static files
   static_templates:
   - 404.html
-
   # Don't include MkDocs' JavaScript
   include_search_page: false
   search_index_only: true
@@ -73,7 +72,13 @@ plugins:
     raise_error: True
     validate_external_urls: True
     raise_error_excludes:
-      404: [ 'https://www.nuget.org/packages/NetEscapades.Configuration.Yaml' ] # No idea why this is failing, but it is.
+      404:
+        [
+          'https://www.nuget.org/packages/NetEscapades.Configuration.Yaml', # No idea why this is failing, but it is.
+          'https://github.com/apps/yamburger', # Archived August 2025
+          'https://github.com/apps/triage-new-issues', # No longer available
+          'https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.Query' # Broken Azure SDK link
+        ]
       405: [ '*' ]
       520: [ '*' ]
       403: [ 'https://www.mend.io/free-developer-tools/blog/overcoming-dockers-mutable-image-tags/' ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,7 @@ site_name: Promitor - Documentation
 site_url: https://promitor.io
 site_author: Tom Kerkhove
 site_description: >-
-  Bringing Azure Monitor metrics
-  where you need them
+  Bringing Azure Monitor metrics where you need them
 
 # Repository
 repo_name: promitor/docs
@@ -21,7 +20,7 @@ theme:
 
   # Static files
   static_templates:
-    - 404.html
+  - 404.html
 
   # Don't include MkDocs' JavaScript
   include_search_page: false
@@ -30,32 +29,32 @@ theme:
   # Default values, taken from mkdocs_theme.yml
   language: en
   features:
-    - navigation.expand
-    - navigation.sections
-    - navigation.tabs.sticky
-    - navigation.tabs
-    - navigation.indexes
-    - navigation.top
-    - navigation.tracking
-    - toc.follow
-    - content.code.annotate
-    - content.tabs.link
-    - search.highlight
-    - search.share
-    - search.suggest
+  - navigation.expand
+  - navigation.sections
+  - navigation.tabs.sticky
+  - navigation.tabs
+  - navigation.indexes
+  - navigation.top
+  - navigation.tracking
+  - toc.follow
+  - content.code.annotate
+  - content.tabs.link
+  - search.highlight
+  - search.share
+  - search.suggest
   palette:
-    - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/lightbulb-outline
-        name: Switch to dark mode
-    - scheme: slate
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/lightbulb
-        name: Switch to light mode
+  - scheme: default
+    primary: indigo
+    accent: indigo
+    toggle:
+      icon: material/lightbulb-outline
+      name: Switch to dark mode
+  - scheme: slate
+    primary: indigo
+    accent: indigo
+    toggle:
+      icon: material/lightbulb
+      name: Switch to light mode
   font:
     text: Roboto
     code: Roboto Mono
@@ -65,19 +64,19 @@ theme:
 
 # Plugins
 plugins:
-  - mike:
-      version_selector: true   # set to false to leave out the version selector
-  - search
-  - tags
-  - htmlproofer:
-      enabled: True
-      raise_error: True
-      validate_external_urls: True
-      raise_error_excludes:
-        404: ['https://www.nuget.org/packages/NetEscapades.Configuration.Yaml'] # No idea why this is failing, but it is.
-        405: ['*']
-        520: ['*']
-        403: ['https://www.mend.io/free-developer-tools/blog/overcoming-dockers-mutable-image-tags/']
+- mike:
+    version_selector: true # set to false to leave out the version selector
+- search
+- tags
+- htmlproofer:
+    enabled: True
+    raise_error: True
+    validate_external_urls: True
+    raise_error_excludes:
+      404: [ 'https://www.nuget.org/packages/NetEscapades.Configuration.Yaml' ] # No idea why this is failing, but it is.
+      405: [ '*' ]
+      520: [ '*' ]
+      403: [ 'https://www.mend.io/free-developer-tools/blog/overcoming-dockers-mutable-image-tags/' ]
 
 # Customization
 extra:
@@ -85,18 +84,18 @@ extra:
     provider: google
     property: G-Q2ZZ6S7ZPW
   social:
-    - icon: fontawesome/brands/docker
-      link: https://github.com/tomkerkhove?tab=packages&repo_name=promitor
-      name: Container Registry
-    - icon: fontawesome/brands/github
-      link: https://github.com/promitor/docs
-      name: GitHub
-    - icon: fontawesome/brands/twitter
-      link: https://twitter.com/promitorio
-      name: Follow us on Twitter
-    - icon: fontawesome/solid/heart
-      link: https://github.com/sponsors/promitor
-      name: Sponsor Promitor
+  - icon: fontawesome/brands/docker
+    link: https://github.com/tomkerkhove?tab=packages&repo_name=promitor
+    name: Container Registry
+  - icon: fontawesome/brands/github
+    link: https://github.com/promitor/docs
+    name: GitHub
+  - icon: fontawesome/brands/twitter
+    link: https://twitter.com/promitorio
+    name: Follow us on Twitter
+  - icon: fontawesome/solid/heart
+    link: https://github.com/sponsors/promitor
+    name: Sponsor Promitor
   # Remove generated link to theme as we are sponsoring
   # See https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#generator-notice
   generator: false
@@ -109,177 +108,179 @@ extra_css:
 - stylesheets/extra.css
 
 extra_javascript:
-  - javascripts/mathjax.js
-  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+- javascripts/mathjax.js
+- https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 # Extensions
 markdown_extensions:
-  - admonition
-  - abbr
-  - attr_list # enables HTML elements
-  - def_list
-  - footnotes
-  - meta
-  - md_in_html
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - toc:
-      permalink: true
-  - pymdownx.arithmatex:
-      generic: true
-  - pymdownx.highlight:
-      anchor_linenums: true
-  - pymdownx.inlinehilite
-  - pymdownx.snippets
-  - pymdownx.superfences
+- admonition
+- abbr
+- attr_list # enables HTML elements
+- def_list
+- footnotes
+- meta
+- md_in_html
+- pymdownx.emoji:
+    emoji_index: !!python/name:material.extensions.emoji.twemoji ""
+    emoji_generator: !!python/name:material.extensions.emoji.to_svg ""
+- toc:
+    permalink: true
+- pymdownx.arithmatex:
+    generic: true
+- pymdownx.highlight:
+    anchor_linenums: true
+- pymdownx.inlinehilite
+- pymdownx.snippets
+- pymdownx.superfences
 
 # Page tree
 nav:
-  - Home:
-    - Overview: index.md
-    - Thank You: thank-you.md
-  - How It Works: how-it-works.md
-  - Scraping:
-    - Overview: scraping/overview.md
-    - Metric Labelling: scraping/labels.md
-    - Runtime Configuration: scraping/runtime-configuration.md
-    - Use Batch Scraping (Experimental): scraping/batch-scraping.md
-    - Available Providers:
-      - Generic: scraping/providers/generic-azure-resource.md
-      - Azure API Management: scraping/providers/api-management.md
-      - Azure App Plan: scraping/providers/app-plan.md
-      - Azure Application Gateway: scraping/providers/application-gateway.md
-      - Azure Application Insights: scraping/providers/application-insights.md
-      - Azure Automation account: scraping/providers/automation-account.md
-      - Azure Blob Storage: scraping/providers/blob-storage.md
-      - Azure Cache for Redis: scraping/providers/redis-cache.md
-      - Azure Cache for Redis Enterprise: scraping/providers/redis-enterprise-cache.md
-      - Azure Cognitive Services Account: scraping/providers/cognitive-services-account.md
-      - Azure Content Delivery Network (CDN): scraping/providers/cdn.md
-      - Azure Container Instances: scraping/providers/container-instances.md
-      - Azure Container Registry: scraping/providers/container-registry.md
-      - Azure Cosmos DB: scraping/providers/cosmos-db.md
-      - Azure Database for MariaDB: scraping/providers/maria-db.md
-      - Azure Database for PostgreSQL: scraping/providers/postgresql.md
-      - Azure Database for MySQL: scraping/providers/mysql.md
-      - Azure Data Factory: scraping/providers/data-factory.md
-      - Azure Data Share: scraping/providers/data-share.md
-      - Azure Event Hubs: scraping/providers/event-hubs.md
-      - Azure Express Route Circuit: scraping/providers/express-route-circuit.md
-      - Azure File Storage: scraping/providers/file-storage.md
-      - Azure Firewall: scraping/providers/azure-firewall.md
-      - Azure Front Door: scraping/providers/front-door.md
-      - Azure Function App: scraping/providers/function-app.md
-      - Azure IoT Hub Device Provisioning Service (DPS): scraping/providers/iot-hub-device-provisioning-service.md
-      - Azure IoT Hub: scraping/providers/iot-hub.md
-      - Azure Key Vault: scraping/providers/key-vault.md
-      - Azure Kubernetes Service: scraping/providers/kubernetes.md
-      - Azure Data Explorer Cluster: scraping/providers/data-explorer-clusters.md
-      - Azure Load Balancer: scraping/providers/load-balancer.md
-      - Azure Log Analytics: scraping/providers/log-analytics.md
-      - Azure Logic Apps: scraping/providers/logic-apps.md
-      - Azure Monitor Autoscale: scraping/providers/monitor-autoscale.md
-      - Azure Nat Gateways: scraping/providers/nat-gateway.md
-      - Azure Network Gateway: scraping/providers/network-gateway.md
-      - Azure Network Interface: scraping/providers/network-interface.md
-      - Azure PowerBI Dedicated: scraping/providers/powerbi-dedicated.md
-      - Azure Public IP Address: scraping/providers/public-ip-address.md
-      - Azure Service Bus Namespace: scraping/providers/service-bus-namespace.md
-      - Azure SQL Database: scraping/providers/sql-database.md
-      - Azure SQL Elastic Pool: scraping/providers/sql-elastic-pool.md
-      - Azure SQL Managed Instance: scraping/providers/sql-managed-instance.md
-      - Azure SQL Server: scraping/providers/sql-server.md
-      - Azure Storage Account: scraping/providers/storage-account.md
-      - Azure Storage Queue: scraping/providers/storage-queue.md
-      - Azure Synapse (Apache Spark pool): scraping/providers/synapse-apache-spark-pool.md
-      - Azure Synapse (SQL pool): scraping/providers/synapse-sql-pool.md
-      - Azure Synapse (Workspace): scraping/providers/synapse-workspace.md
-      - Azure Traffic Manager: scraping/providers/traffic-manager.md
-      - Azure Virtual Machine Scale Set (VMSS): scraping/providers/virtual-machine-scale-set.md
-      - Azure Virtual Machine (VM): scraping/providers/virtual-machine.md
-      - Azure Virtual Network: scraping/providers/virtual-network.md
-      - Azure Web App: scraping/providers/web-app.md
+- Home:
+  - Overview: index.md
+  - Thank You: thank-you.md
+- How It Works: how-it-works.md
+- Scraping:
+  - Overview: scraping/overview.md
+  - Metric Labelling: scraping/labels.md
+  - Runtime Configuration: scraping/runtime-configuration.md
+  - Use Batch Scraping (Experimental): scraping/batch-scraping.md
+  - Available Providers:
+    - Generic: scraping/providers/generic-azure-resource.md
+    - Azure API Management: scraping/providers/api-management.md
+    - Azure App Plan: scraping/providers/app-plan.md
+    - Azure Application Gateway: scraping/providers/application-gateway.md
+    - Azure Application Insights: scraping/providers/application-insights.md
+    - Azure Automation account: scraping/providers/automation-account.md
+    - Azure Blob Storage: scraping/providers/blob-storage.md
+    - Azure Cache for Redis: scraping/providers/redis-cache.md
+    - Azure Cache for Redis Enterprise: scraping/providers/redis-enterprise-cache.md
+    - Azure Cognitive Services Account: scraping/providers/cognitive-services-account.md
+    - Azure Content Delivery Network (CDN): scraping/providers/cdn.md
+    - Azure Container Instances: scraping/providers/container-instances.md
+    - Azure Container Registry: scraping/providers/container-registry.md
+    - Azure Cosmos DB: scraping/providers/cosmos-db.md
+    - Azure Database for MariaDB: scraping/providers/maria-db.md
+    - Azure Database for PostgreSQL: scraping/providers/postgresql.md
+    - Azure Database for MySQL: scraping/providers/mysql.md
+    - Azure DNS Zone: scraping/providers/dns-zone.md
+    - Azure Data Factory: scraping/providers/data-factory.md
+    - Azure Data Share: scraping/providers/data-share.md
+    - Azure Event Hubs: scraping/providers/event-hubs.md
+    - Azure Express Route Circuit: scraping/providers/express-route-circuit.md
+    - Azure File Storage: scraping/providers/file-storage.md
+    - Azure Firewall: scraping/providers/azure-firewall.md
+    - Azure Front Door: scraping/providers/front-door.md
+    - Azure Function App: scraping/providers/function-app.md
+    - Azure IoT Hub Device Provisioning Service (DPS): scraping/providers/iot-hub-device-provisioning-service.md
+    - Azure IoT Hub: scraping/providers/iot-hub.md
+    - Azure Key Vault: scraping/providers/key-vault.md
+    - Azure Kubernetes Service: scraping/providers/kubernetes.md
+    - Azure Data Explorer Cluster: scraping/providers/data-explorer-clusters.md
+    - Azure Load Balancer: scraping/providers/load-balancer.md
+    - Azure Log Analytics: scraping/providers/log-analytics.md
+    - Azure Logic Apps: scraping/providers/logic-apps.md
+    - Azure Monitor Autoscale: scraping/providers/monitor-autoscale.md
+    - Azure Nat Gateways: scraping/providers/nat-gateway.md
+    - Azure Network Gateway: scraping/providers/network-gateway.md
+    - Azure Network Interface: scraping/providers/network-interface.md
+    - Azure PowerBI Dedicated: scraping/providers/powerbi-dedicated.md
+    - Azure Public IP Address: scraping/providers/public-ip-address.md
+    - Azure Service Bus Namespace: scraping/providers/service-bus-namespace.md
+    - Azure SQL Database: scraping/providers/sql-database.md
+    - Azure SQL Elastic Pool: scraping/providers/sql-elastic-pool.md
+    - Azure SQL Managed Instance: scraping/providers/sql-managed-instance.md
+    - Azure SQL Server: scraping/providers/sql-server.md
+    - Azure Storage Account: scraping/providers/storage-account.md
+    - Azure Storage Queue: scraping/providers/storage-queue.md
+    - Azure Synapse (Apache Spark pool): scraping/providers/synapse-apache-spark-pool.md
+    - Azure Synapse (SQL pool): scraping/providers/synapse-sql-pool.md
+    - Azure Synapse (Workspace): scraping/providers/synapse-workspace.md
+    - Azure Traffic Manager: scraping/providers/traffic-manager.md
+    - Azure Virtual Machine Scale Set (VMSS): scraping/providers/virtual-machine-scale-set.md
+    - Azure Virtual Machine (VM): scraping/providers/virtual-machine.md
+    - Azure Virtual Network: scraping/providers/virtual-network.md
+    - Azure Web App: scraping/providers/web-app.md
+- Resource Discovery:
+  - Overview: resource-discovery/overview.md
+  - Declaring resource discovery groups: resource-discovery/declaring-resource-discovery-groups.md
+  - Runtime Configuration: resource-discovery/runtime-configuration.md
+  - Supported Providers:
+    - Azure API Management: scraping/providers/api-management.md
+    - Azure App Plan: scraping/providers/app-plan.md
+    - Azure Application Gateway: scraping/providers/application-gateway.md
+    - Azure Application Insights: scraping/providers/application-insights.md
+    - Azure Automation account: scraping/providers/automation-account.md
+    - Azure Cache for Redis: scraping/providers/redis-cache.md
+    - Azure Cache for Redis Enterprise: scraping/providers/redis-enterprise-cache.md
+    - Azure Cognitive Services Account: scraping/providers/cognitive-services-account.md
+    - Azure Content Delivery Network (CDN): scraping/providers/cdn.md
+    - Azure Container Instances: scraping/providers/container-instances.md
+    - Azure Container Registry: scraping/providers/container-registry.md
+    - Azure Cosmos DB: scraping/providers/cosmos-db.md
+    - Azure Database for MariaDB: scraping/providers/maria-db.md
+    - Azure Database for PostgreSQL: scraping/providers/postgresql.md
+    - Azure Database for MySQL: scraping/providers/mysql.md
+    - Azure DNS Zone: scraping/providers/dns-zone.md
+    - Azure Data Factory: scraping/providers/data-factory.md
+    - Azure Data Share: scraping/providers/data-share.md
+    - Azure Event Hubs: scraping/providers/event-hubs.md
+    - Azure Express Route Circuit: scraping/providers/express-route-circuit.md
+    - Azure File Storage: scraping/providers/file-storage.md
+    - Azure Firewall: scraping/providers/azure-firewall.md
+    - Azure Front Door: scraping/providers/front-door.md
+    - Azure Function App: scraping/providers/function-app.md
+    - Azure IoT Hub Device Provisioning Service (DPS): scraping/providers/iot-hub-device-provisioning-service.md
+    - Azure IoT Hub: scraping/providers/iot-hub.md
+    - Azure Key Vault: scraping/providers/key-vault.md
+    - Azure Kubernetes Service: scraping/providers/kubernetes.md
+    - Azure Data Explorer Cluster: scraping/providers/data-explorer-clusters.md
+    - Azure Load Balancer: scraping/providers/load-balancer.md
+    - Azure Logic Apps: scraping/providers/logic-apps.md
+    - Azure Monitor Autoscale: scraping/providers/monitor-autoscale.md
+    - Azure Nat Gateways: scraping/providers/nat-gateway.md
+    - Azure Network Gateway: scraping/providers/network-gateway.md
+    - Azure Network Interface: scraping/providers/network-interface.md
+    - Azure PowerBI Dedicated: scraping/providers/powerbi-dedicated.md
+    - Azure Public IP Address: scraping/providers/public-ip-address.md
+    - Azure Service Bus Namespace: scraping/providers/service-bus-namespace.md
+    - Azure SQL Database: scraping/providers/sql-database.md
+    - Azure SQL Elastic Pool: scraping/providers/sql-elastic-pool.md
+    - Azure SQL Managed Instance: scraping/providers/sql-managed-instance.md
+    - Azure SQL Managed Instance: scraping/providers/sql-managed-instance.md
+    - Azure Storage Account: scraping/providers/storage-account.md
+    - Azure Synapse (Apache Spark pool): scraping/providers/synapse-apache-spark-pool.md
+    - Azure Synapse (SQL pool): scraping/providers/synapse-sql-pool.md
+    - Azure Synapse (Workspace): scraping/providers/synapse-workspace.md
+    - Azure Traffic Manager: scraping/providers/traffic-manager.md
+    - Azure Virtual Machine Scale Set (VMSS): scraping/providers/virtual-machine-scale-set.md
+    - Azure Virtual Machine (VM): scraping/providers/virtual-machine.md
+    - Azure Virtual Network: scraping/providers/virtual-network.md
+    - Azure Web App: scraping/providers/web-app.md
+- Deployment:
+  - Overview: deployment/index.md
+  - Scraper:
+    - Overview: deployment/scraper/index.md
+    - Docker: deployment/scraper/docker.md
+    - Kubernetes: deployment/scraper/kubernetes.md
   - Resource Discovery:
-    - Overview: resource-discovery/overview.md
-    - Declaring resource discovery groups: resource-discovery/declaring-resource-discovery-groups.md
-    - Runtime Configuration: resource-discovery/runtime-configuration.md
-    - Supported Providers:
-      - Azure API Management: scraping/providers/api-management.md
-      - Azure App Plan: scraping/providers/app-plan.md
-      - Azure Application Gateway: scraping/providers/application-gateway.md
-      - Azure Application Insights: scraping/providers/application-insights.md
-      - Azure Automation account: scraping/providers/automation-account.md
-      - Azure Cache for Redis: scraping/providers/redis-cache.md
-      - Azure Cache for Redis Enterprise: scraping/providers/redis-enterprise-cache.md
-      - Azure Cognitive Services Account: scraping/providers/cognitive-services-account.md
-      - Azure Content Delivery Network (CDN): scraping/providers/cdn.md
-      - Azure Container Instances: scraping/providers/container-instances.md
-      - Azure Container Registry: scraping/providers/container-registry.md
-      - Azure Cosmos DB: scraping/providers/cosmos-db.md
-      - Azure Database for MariaDB: scraping/providers/maria-db.md
-      - Azure Database for PostgreSQL: scraping/providers/postgresql.md
-      - Azure Database for MySQL: scraping/providers/mysql.md
-      - Azure Data Factory: scraping/providers/data-factory.md
-      - Azure Data Share: scraping/providers/data-share.md
-      - Azure Event Hubs: scraping/providers/event-hubs.md
-      - Azure Express Route Circuit: scraping/providers/express-route-circuit.md
-      - Azure File Storage: scraping/providers/file-storage.md
-      - Azure Firewall: scraping/providers/azure-firewall.md
-      - Azure Front Door: scraping/providers/front-door.md
-      - Azure Function App: scraping/providers/function-app.md
-      - Azure IoT Hub Device Provisioning Service (DPS): scraping/providers/iot-hub-device-provisioning-service.md
-      - Azure IoT Hub: scraping/providers/iot-hub.md
-      - Azure Key Vault: scraping/providers/key-vault.md
-      - Azure Kubernetes Service: scraping/providers/kubernetes.md
-      - Azure Data Explorer Cluster: scraping/providers/data-explorer-clusters.md
-      - Azure Load Balancer: scraping/providers/load-balancer.md
-      - Azure Logic Apps: scraping/providers/logic-apps.md
-      - Azure Monitor Autoscale: scraping/providers/monitor-autoscale.md
-      - Azure Nat Gateways: scraping/providers/nat-gateway.md
-      - Azure Network Gateway: scraping/providers/network-gateway.md
-      - Azure Network Interface: scraping/providers/network-interface.md
-      - Azure PowerBI Dedicated: scraping/providers/powerbi-dedicated.md
-      - Azure Public IP Address: scraping/providers/public-ip-address.md
-      - Azure Service Bus Namespace: scraping/providers/service-bus-namespace.md
-      - Azure SQL Database: scraping/providers/sql-database.md
-      - Azure SQL Elastic Pool: scraping/providers/sql-elastic-pool.md
-      - Azure SQL Managed Instance: scraping/providers/sql-managed-instance.md
-      - Azure SQL Managed Instance: scraping/providers/sql-managed-instance.md
-      - Azure Storage Account: scraping/providers/storage-account.md
-      - Azure Synapse (Apache Spark pool): scraping/providers/synapse-apache-spark-pool.md
-      - Azure Synapse (SQL pool): scraping/providers/synapse-sql-pool.md
-      - Azure Synapse (Workspace): scraping/providers/synapse-workspace.md
-      - Azure Traffic Manager: scraping/providers/traffic-manager.md
-      - Azure Virtual Machine Scale Set (VMSS): scraping/providers/virtual-machine-scale-set.md
-      - Azure Virtual Machine (VM): scraping/providers/virtual-machine.md
-      - Azure Virtual Network: scraping/providers/virtual-network.md
-      - Azure Web App: scraping/providers/web-app.md
-  - Deployment:
-    - Overview: deployment/index.md
-    - Scraper: 
-      - Overview: deployment/scraper/index.md
-      - Docker: deployment/scraper/docker.md
-      - Kubernetes: deployment/scraper/kubernetes.md
-    - Resource Discovery:
-      - Overview: deployment/resource-discovery/index.md
-      - Docker: deployment/resource-discovery/docker.md
-      - Kubernetes: deployment/resource-discovery/kubernetes.md
-  - Security:
-    - Authentication with Microsoft Azure: security/azure-authentication.md
-  - Operations:
-    - Overview: operations/index.md
-    - Health: operations/health.md
-    - Resource Discovery: operations/discovery.md
-    - Performance: operations/performance.md
-    - System: operations/system.md
-    - Integrations: operations/integrations.md
-    # - Configuration REST APIs: not found
-  - Walkthroughs:
-    - Deploying Promitor, Prometheus, and Grafana on an AKS Cluster: walkthroughs/scrape-promitor-with-prometheus-on-azure-kubernetes-service.md
-    - Using Managed Identity with Promitor on an AKS Cluster: walkthroughs/use-promitor-with-managed-identity.md
-    - Migrate from Promitor Scraper 1.x to 2.x: walkthroughs/migrate-from-1.x-to-2.x.md
-  - FAQ: faq.md
+    - Overview: deployment/resource-discovery/index.md
+    - Docker: deployment/resource-discovery/docker.md
+    - Kubernetes: deployment/resource-discovery/kubernetes.md
+- Security:
+  - Authentication with Microsoft Azure: security/azure-authentication.md
+- Operations:
+  - Overview: operations/index.md
+  - Health: operations/health.md
+  - Resource Discovery: operations/discovery.md
+  - Performance: operations/performance.md
+  - System: operations/system.md
+  - Integrations: operations/integrations.md
+  # - Configuration REST APIs: not found
+- Walkthroughs:
+  - Deploying Promitor, Prometheus, and Grafana on an AKS Cluster: walkthroughs/scrape-promitor-with-prometheus-on-azure-kubernetes-service.md
+  - Using Managed Identity with Promitor on an AKS Cluster: walkthroughs/use-promitor-with-managed-identity.md
+  - Migrate from Promitor Scraper 1.x to 2.x: walkthroughs/migrate-from-1.x-to-2.x.md
+- FAQ: faq.md
 
 # Tweaks
 strict: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,16 +72,10 @@ plugins:
     raise_error: True
     validate_external_urls: True
     raise_error_excludes:
-      404:
-        [
-          'https://www.nuget.org/packages/NetEscapades.Configuration.Yaml', # No idea why this is failing, but it is.
-          'https://github.com/apps/yamburger', # Archived August 2025
-          'https://github.com/apps/triage-new-issues', # No longer available
-          'https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.Query' # Broken Azure SDK link
-        ]
+      404: [ 'https://www.nuget.org/packages/NetEscapades.Configuration.Yaml', 'https://github.com/apps/yamburger', 'https://github.com/apps/triage-new-issues', 'https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor/Azure.Monitor.Query' ]
       405: [ '*' ]
       520: [ '*' ]
-      403: [ 'https://www.mend.io/free-developer-tools/blog/overcoming-dockers-mutable-image-tags/' ]
+      403: [ 'https://www.mend.io/free-developer-tools/blog/overcoming-dockers-mutable-image-tags/', '*mend.io*' ]
 
 # Customization
 extra:


### PR DESCRIPTION
## Summary

Adds Azure DNS Zone monitoring support to Promitor documentation.

## Changes

- **Added** `dns-zone.md` provider documentation with `RecordSetCapacityUtilization` metric example
- **Updated** overview to include DNS Zone in supported services list
- **Updated** resource discovery documentation with DNS Zone example

## Features

- Resource type: `DnsZone` 
- Required field: `zoneName`
- Supports both static resources and automatic discovery
- Example metric: DNS capacity utilization monitoring

## Usage

```yaml
name: azure_dns_zone_capacity_utilization
description: "Percentage of record set capacity utilized by a DNS zone"
resourceType: DnsZone
azureMetricConfiguration:
  metricName: RecordSetCapacityUtilization
  aggregation:
    type: Maximum
resources:
  - zoneName: example.com
